### PR TITLE
Update/551

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,11 +15,6 @@ repositories {
     jcenter()
 }
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 dependencies {
     testImplementation("junit:junit:4.12")
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,13 +6,13 @@ plugins {
 group = "org.openmicroscopy"
 version = "5.5.1-SNAPSHOT"
 
+repositories {
+    jcenter()
+}
+
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
-}
-
-repositories {
-    jcenter()
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,11 @@ plugins {
 group = "org.openmicroscopy"
 version = "5.5.1-SNAPSHOT"
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 repositories {
     jcenter()
 }

--- a/src/main/groovy/org/openmicroscopy/api/ApiPlugin.groovy
+++ b/src/main/groovy/org/openmicroscopy/api/ApiPlugin.groovy
@@ -45,11 +45,9 @@ class ApiPlugin implements Plugin<Project> {
 
     void configureForJavaPlugin() {
         project.plugins.withType(JavaPlugin) { JavaPlugin java ->
-            project.afterEvaluate {
-                project.tasks.withType(SplitTask).each { SplitTask splitTask ->
-                    if (splitTask.language.get() == Language.JAVA) {
-                        Task compileJava =
-                                project.tasks.getByName(JavaPlugin.COMPILE_JAVA_TASK_NAME)
+            project.tasks.withType(SplitTask).configureEach { SplitTask splitTask ->
+                if (splitTask.language.get() == Language.JAVA) {
+                    project.tasks.getByName(JavaPlugin.COMPILE_JAVA_TASK_NAME) { Task compileJava ->
                         compileJava.dependsOn(splitTask)
                     }
                 }

--- a/src/main/groovy/org/openmicroscopy/api/ApiPlugin.groovy
+++ b/src/main/groovy/org/openmicroscopy/api/ApiPlugin.groovy
@@ -25,6 +25,8 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.tasks.SourceSet
 import org.openmicroscopy.api.tasks.SplitTask
 import org.openmicroscopy.api.types.Language
 
@@ -47,9 +49,19 @@ class ApiPlugin implements Plugin<Project> {
         project.plugins.withType(JavaPlugin) { JavaPlugin java ->
             project.tasks.withType(SplitTask).configureEach { SplitTask splitTask ->
                 if (splitTask.language.get() == Language.JAVA) {
+                    // Set Java compileJava task to depend on the splitJava task
                     project.tasks.getByName(JavaPlugin.COMPILE_JAVA_TASK_NAME) { Task compileJava ->
                         compileJava.dependsOn(splitTask)
                     }
+
+                    // Set java source set to include output of splitJava
+                    JavaPluginConvention javaConvention =
+                            project.convention.getPlugin(JavaPluginConvention)
+
+                    SourceSet main =
+                            javaConvention.sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
+
+                    main.java.srcDirs(splitTask.outputDir)
                 }
             }
         }

--- a/src/main/groovy/org/openmicroscopy/api/ApiPluginBase.groovy
+++ b/src/main/groovy/org/openmicroscopy/api/ApiPluginBase.groovy
@@ -42,7 +42,7 @@ class ApiPluginBase implements Plugin<Project> {
 
     public static final String EXTENSION_NAME_API = "api"
 
-    public static final String TASK_PREFIX_GENERATE = "generate"
+    public static final String TASK_PREFIX_COMBINED_TO = "combinedTo"
 
     private static final def Log = Logging.getLogger(ApiPluginBase)
 
@@ -50,7 +50,7 @@ class ApiPluginBase implements Plugin<Project> {
     void apply(Project project) {
         ApiExtension api = createBaseExtension(project)
 
-        api.language.whenObjectAdded { SplitExtension split ->
+        api.language.configureEach { SplitExtension split ->
             registerSplitTask(project, api, split)
         }
     }
@@ -62,19 +62,17 @@ class ApiPluginBase implements Plugin<Project> {
     }
 
     static void registerSplitTask(Project project, ApiExtension api, SplitExtension split) {
-        String taskName = TASK_PREFIX_GENERATE + split.name.capitalize()
+        String taskName = TASK_PREFIX_COMBINED_TO + split.name.capitalize()
         project.tasks.register(taskName, SplitTask, new Action<SplitTask>() {
             @Override
             void execute(SplitTask t) {
-                t.with {
-                    group = GROUP
-                    setDescription("Splits ${split.language} from .combined files")
-                    setOutputDir(split.outputDir.flatMap { File f -> api.outputDir.dir(f.toString()) })
-                    setLanguage(split.language)
-                    setNamer(split.renamer)
-                    source api.combinedFiles + split.combinedFiles
-                    include "**/*.combined"
-                }
+                t.group = GROUP
+                t.setDescription("Splits ${split.language} from .combined files")
+                t.setOutputDir(split.outputDir.flatMap { File f -> api.outputDir.dir(f.toString()) })
+                t.setLanguage(split.language)
+                t.setNamer(split.renamer)
+                t.source api.combinedFiles + split.combinedFiles
+                t.include "**/*.combined"
             }
         })
     }

--- a/src/main/groovy/org/openmicroscopy/api/ApiPluginBase.groovy
+++ b/src/main/groovy/org/openmicroscopy/api/ApiPluginBase.groovy
@@ -62,17 +62,18 @@ class ApiPluginBase implements Plugin<Project> {
     }
 
     static void registerSplitTask(Project project, ApiExtension api, SplitExtension split) {
-        String taskName = TASK_PREFIX_COMBINED_TO + split.name.capitalize()
+        String taskName = api.createTaskName(split.name)
+
         project.tasks.register(taskName, SplitTask, new Action<SplitTask>() {
             @Override
-            void execute(SplitTask t) {
-                t.group = GROUP
-                t.setDescription("Splits ${split.language} from .combined files")
-                t.setOutputDir(split.outputDir.flatMap { File f -> api.outputDir.dir(f.toString()) })
-                t.setLanguage(split.language)
-                t.setNamer(split.renamer)
-                t.source api.combinedFiles + split.combinedFiles
-                t.include "**/*.combined"
+            void execute(SplitTask task) {
+                task.group = GROUP
+                task.setDescription("Splits ${split.language} from .combined files")
+                task.setOutputDir(split.outputDir.flatMap { File f -> api.outputDir.dir(f.toString()) })
+                task.setLanguage(split.language)
+                task.setNamer(split.renamer)
+                task.source api.combinedFiles + split.combinedFiles
+                task.include "**/*.combined"
             }
         })
     }

--- a/src/main/groovy/org/openmicroscopy/api/extensions/ApiExtension.groovy
+++ b/src/main/groovy/org/openmicroscopy/api/extensions/ApiExtension.groovy
@@ -27,6 +27,9 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Provider
+import org.openmicroscopy.api.ApiPluginBase
+
+import java.util.concurrent.Callable
 
 class ApiExtension {
 
@@ -46,6 +49,15 @@ class ApiExtension {
 
         // Set conventions
         this.outputDir.convention(project.layout.projectDirectory.dir("src/api"))
+    }
+
+    Provider<String> createTaskName(String name) {
+        project.providers.provider(new Callable<String>() {
+            @Override
+            String call() throws Exception {
+                return ApiPluginBase.TASK_PREFIX_COMBINED_TO + name.capitalize()
+            }
+        })
     }
 
     void language(Action<? super NamedDomainObjectContainer<SplitExtension>> action) {

--- a/src/main/groovy/org/openmicroscopy/api/extensions/ApiExtension.groovy
+++ b/src/main/groovy/org/openmicroscopy/api/extensions/ApiExtension.groovy
@@ -48,7 +48,7 @@ class ApiExtension {
         this.outputDir = project.objects.directoryProperty()
 
         // Set conventions
-        this.outputDir.convention(project.layout.projectDirectory.dir("src/api"))
+        this.outputDir.convention(project.layout.buildDirectory.dir("api"))
     }
 
     Provider<String> createTaskName(String name) {

--- a/src/main/groovy/org/openmicroscopy/api/extensions/SplitExtension.groovy
+++ b/src/main/groovy/org/openmicroscopy/api/extensions/SplitExtension.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.Project
 import org.gradle.api.Transformer
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.openmicroscopy.api.types.Language
 import org.openmicroscopy.api.utils.ApiNamer
 
@@ -109,6 +110,10 @@ class SplitExtension {
 
     void setOutputDir(File dir) {
         this.outputDir.set(dir)
+    }
+
+    void setOutputDir(Provider<? extends File> provider) {
+        this.outputDir.set(provider)
     }
 
     void rename(Transformer<? extends String, ? extends String> renamer) {

--- a/src/main/groovy/org/openmicroscopy/api/tasks/SplitTask.groovy
+++ b/src/main/groovy/org/openmicroscopy/api/tasks/SplitTask.groovy
@@ -71,7 +71,7 @@ class SplitTask extends SourceTask {
             // Assign default to rename
             ApiNamer apiNamer = namer.getOrElse(new ApiNamer())
 
-            project.sync { CopySpec c ->
+            project.copy { CopySpec c ->
                 c.into outputDir.get()
                 c.from getSource()
                 c.rename apiNamer.getRenamer(prefix)

--- a/src/main/groovy/org/openmicroscopy/api/tasks/SplitTask.groovy
+++ b/src/main/groovy/org/openmicroscopy/api/tasks/SplitTask.groovy
@@ -72,7 +72,7 @@ class SplitTask extends SourceTask {
             ApiNamer apiNamer = namer.getOrElse(new ApiNamer())
 
             project.sync { CopySpec c ->
-                c.into outputDir
+                c.into outputDir.get()
                 c.from getSource()
                 c.rename apiNamer.getRenamer(prefix)
                 c.filter { String line -> filerLine(line, prefixName) }


### PR DESCRIPTION
Fixes bug (`copy` vs `sync`) where SplitTask overwrites the contents of its output directory.

Sets task ordering for `combinedToJava` tasks.
